### PR TITLE
Add build scripts for ServerB using cb-mpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # cb-mpc-demo
-cb-mpc-demo
+
+Example demonstrating how to build ServerB using Coinbase's [cb-mpc](https://github.com/coinbase/cb-mpc) library.
+
+## Build scripts
+
+The `scripts/` directory contains helper scripts:
+
+1. `install_dependencies.sh` – installs system packages required for building and verifies they were installed.
+2. `install_cbmpc.sh` – clones and builds the `cb-mpc` repository and installs the FFI library under `/usr/local/opt/cbmpc` by default.
+3. `source_cbmpc_env.sh` – sets `CBMPC_HOME`, `LD_LIBRARY_PATH`, and `PKG_CONFIG_PATH` for the current shell.
+4. `build_serverb.sh` – compiles `ServerB/mpc_partyB.cpp` using the locally installed `cb-mpc` library.
+
+Each command in the scripts is followed by a simple test to ensure progress.
+
+## Usage
+
+```bash
+# Install build tools and libraries
+./scripts/install_dependencies.sh
+
+# Build and install cb-mpc
+./scripts/install_cbmpc.sh
+
+# Set environment variables for this session
+source ./scripts/source_cbmpc_env.sh
+
+# Compile ServerB
+./scripts/build_serverb.sh
+```
+
+Adjust `CBMPC_HOME` if the cb-mpc library is installed in a different location.

--- a/scripts/build_serverb.sh
+++ b/scripts/build_serverb.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CBMPC_HOME=${CBMPC_HOME:-/usr/local/opt/cbmpc}
+# Tests: ensure CBMPC_HOME exists
+[ -d "$CBMPC_HOME/include" ]
+[ -d "$CBMPC_HOME/lib" ]
+
+echo "Using CBMPC from $CBMPC_HOME"
+
+# Create build directory
+mkdir -p build
+[ -d build ]
+
+# Compile ServerB
+pkg_config_cflags=$(pkg-config --cflags libcurl)
+pkg_config_libs=$(pkg-config --libs libcurl)
+
+g++ -std=c++17 ServerB/mpc_partyB.cpp ServerB/http_transport.cpp \
+    -I"$CBMPC_HOME/include" $pkg_config_cflags \
+    -L"$CBMPC_HOME/lib" -lcbmpc $pkg_config_libs \
+    -o build/mpc_partyB
+# Test: binary exists
+[ -x build/mpc_partyB ]
+
+echo "ServerB built: build/mpc_partyB"

--- a/scripts/install_cbmpc.sh
+++ b/scripts/install_cbmpc.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CBMPC_HOME=${CBMPC_HOME:-/usr/local/opt/cbmpc}
+REPO_DIR="cb-mpc"
+
+# Clone cb-mpc
+if [ ! -d "$REPO_DIR" ]; then
+  git clone https://github.com/coinbase/cb-mpc.git "$REPO_DIR"
+fi
+# Test: repository exists
+[ -d "$REPO_DIR/.git" ]
+
+cd "$REPO_DIR"
+# Ensure submodules fetched (if any)
+git submodule update --init --recursive
+# Test: presence of Cargo.toml indicates repository ready
+[ -f Cargo.toml ]
+
+# Build FFI library
+cargo build --release -p cb-mpc-ffi
+# Test: library built
+[ -f target/release/libcbmpc.a ]
+
+# Install library and header
+sudo mkdir -p "$CBMPC_HOME/lib" "$CBMPC_HOME/include"
+sudo cp target/release/libcbmpc.a "$CBMPC_HOME/lib/"
+# Header path may change; adjust if needed
+default_header="ffi/c/include/cbmpc.h"
+if [ -f "$default_header" ]; then
+  sudo cp "$default_header" "$CBMPC_HOME/include/"
+fi
+# Tests: verify installation
+[ -f "$CBMPC_HOME/lib/libcbmpc.a" ]
+[ -f "$CBMPC_HOME/include/cbmpc.h" ]
+
+echo "cb-mpc installed to $CBMPC_HOME"

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Update package index
+sudo apt-get update
+# Test: ensure apt cache is accessible
+apt-cache policy build-essential > /dev/null
+
+echo "Installing build tools and libraries..."
+sudo apt-get install -y build-essential cmake pkg-config git curl libcurl4-openssl-dev
+# Tests: verify commands installed
+command -v g++ >/dev/null
+cmake --version >/dev/null
+pkg-config --version >/dev/null
+git --version >/dev/null
+curl --version >/dev/null
+
+echo "Dependency installation complete."

--- a/scripts/source_cbmpc_env.sh
+++ b/scripts/source_cbmpc_env.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CBMPC_HOME=${CBMPC_HOME:-/usr/local/opt/cbmpc}
+export CBMPC_HOME
+export LD_LIBRARY_PATH="$CBMPC_HOME/lib:${LD_LIBRARY_PATH:-}"
+export PKG_CONFIG_PATH="$CBMPC_HOME/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+
+# Tests: print variables to confirm
+[ -d "$CBMPC_HOME" ]
+[ -n "$LD_LIBRARY_PATH" ]
+[ -n "$PKG_CONFIG_PATH" ]
+
+echo "CBMPC_HOME=$CBMPC_HOME"
+echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"


### PR DESCRIPTION
## Summary
- Add installation script for required system packages
- Add helper to clone/build Coinbase cb-mpc and install headers/libs
- Add environment variable setup and compilation scripts for ServerB
- Document build flow in README

## Testing
- `./scripts/install_dependencies.sh` *(fails: 403 Forbidden while fetching packages)*
- `./scripts/install_cbmpc.sh` *(fails: CONNECT tunnel failed when cloning cb-mpc)*
- `./scripts/build_serverb.sh && echo OK || echo FAIL` *(fails: missing cb-mpc installation)*
- `./scripts/source_cbmpc_env.sh && echo OK || echo FAIL` *(fails: missing cb-mpc installation)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7eec4a2c8321875bd67bead75e94