### PR TITLE
Improve cb-mpc build scripts

### DIFF
--- a/scripts/build_serverb.sh
+++ b/scripts/build_serverb.sh
@@ -2,9 +2,11 @@
 set -euo pipefail
 
 CBMPC_HOME=${CBMPC_HOME:-/usr/local/opt/cbmpc}
-# Tests: ensure CBMPC_HOME exists
-[ -d "$CBMPC_HOME/include" ]
-[ -d "$CBMPC_HOME/lib" ]
+# Ensure cb-mpc installation exists and fail with a helpful message otherwise
+if [ ! -d "$CBMPC_HOME/include" ] || [ ! -d "$CBMPC_HOME/lib" ]; then
+  echo "cb-mpc not found under $CBMPC_HOME. Did you run scripts/install_cbmpc.sh?" >&2
+  exit 1
+fi
 
 echo "Using CBMPC from $CBMPC_HOME"
 

--- a/scripts/install_cbmpc.sh
+++ b/scripts/install_cbmpc.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 CBMPC_HOME=${CBMPC_HOME:-/usr/local/opt/cbmpc}
-REPO_DIR="cb-mpc"
+
+# Always place the cb-mpc repository at the project root so running this
+# script from any directory doesn't litter the scripts folder.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$SCRIPT_DIR/../cb-mpc"
 
 # Clone cb-mpc
 if [ ! -d "$REPO_DIR" ]; then


### PR DESCRIPTION
## Summary
- Ensure install_cbmpc.sh always clones cb-mpc in the project root
- Fail early in build_serverb.sh with a helpful message if cb-mpc isn't installed

## Testing
- `./scripts/install_cbmpc.sh` (failed: CONNECT tunnel failed, response 403)
- `./scripts/build_serverb.sh` (fails: cb-mpc not found under /usr/local/opt/cbmpc)


------
https://chatgpt.com/codex/tasks/task_e_68ab81967b6c8321974608f24430e26e