### PR TITLE
Clone cb-mpc into CBMPC_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Example demonstrating how to build ServerB using Coinbase's [cb-mpc](https://git
 The `scripts/` directory contains helper scripts:
 
 1. `install_dependencies.sh` – installs system packages required for building and verifies they were installed.
-2. `install_cbmpc.sh` – clones and builds the `cb-mpc` repository and installs the FFI library under `/usr/local/opt/cbmpc` by default.
+2. `install_cbmpc.sh` – clones the `cb-mpc` repository into `$CBMPC_HOME/cb-mpc`, builds it, and installs the FFI library under `/usr/local/opt/cbmpc` by default.
 3. `source_cbmpc_env.sh` – sets `CBMPC_HOME`, `LD_LIBRARY_PATH`, and `PKG_CONFIG_PATH` for the current shell.
 4. `build_serverb.sh` – compiles `ServerB/mpc_partyB.cpp` using the locally installed `cb-mpc` library.
 

--- a/scripts/install_cbmpc.sh
+++ b/scripts/install_cbmpc.sh
@@ -3,14 +3,14 @@ set -euo pipefail
 
 CBMPC_HOME=${CBMPC_HOME:-/usr/local/opt/cbmpc}
 
-# Always place the cb-mpc repository at the project root so running this
-# script from any directory doesn't litter the scripts folder.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_DIR="$SCRIPT_DIR/../cb-mpc"
+# Place the cb-mpc sources under CBMPC_HOME to avoid cluttering the project tree.
+REPO_DIR="$CBMPC_HOME/cb-mpc"
 
 # Clone cb-mpc
 if [ ! -d "$REPO_DIR" ]; then
-  git clone https://github.com/coinbase/cb-mpc.git "$REPO_DIR"
+  sudo mkdir -p "$CBMPC_HOME"
+  sudo git clone https://github.com/coinbase/cb-mpc.git "$REPO_DIR"
+  sudo chown -R "$(id -u):$(id -g)" "$REPO_DIR"
 fi
 # Test: repository exists
 [ -d "$REPO_DIR/.git" ]


### PR DESCRIPTION
## Summary
- clone the cb-mpc sources inside `$CBMPC_HOME/cb-mpc` instead of the scripts directory
- document new repository location in README

## Testing
- `bash -n scripts/install_cbmpc.sh`
- `CBMPC_HOME=/tmp/cbmpc-test ./scripts/install_cbmpc.sh` *(fails: `fatal: unable to access 'https://github.com/coinbase/cb-mpc.git/': CONNECT tunnel failed, response 403`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab843011a0832190758174e31ed703