### PR TITLE
Handle nested cb-mpc installation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ source ./scripts/source_cbmpc_env.sh
 ```
 
 Adjust `CBMPC_HOME` if the cb-mpc library is installed in a different location.
+The scripts will also check `$CBMPC_HOME/cb-mpc` in case the library and
+headers were installed inside the cb-mpc repository itself.

--- a/scripts/build_serverb.sh
+++ b/scripts/build_serverb.sh
@@ -2,10 +2,17 @@
 set -euo pipefail
 
 CBMPC_HOME=${CBMPC_HOME:-/usr/local/opt/cbmpc}
-# Ensure cb-mpc installation exists and fail with a helpful message otherwise
+
+# Ensure cb-mpc installation exists and fall back to a nested repository path
+# if the library was installed inside the cb-mpc source tree
 if [ ! -d "$CBMPC_HOME/include" ] || [ ! -d "$CBMPC_HOME/lib" ]; then
-  echo "cb-mpc not found under $CBMPC_HOME. Did you run scripts/install_cbmpc.sh?" >&2
-  exit 1
+  alt="$CBMPC_HOME/cb-mpc"
+  if [ -d "$alt/include" ] && [ -d "$alt/lib" ]; then
+    CBMPC_HOME="$alt"
+  else
+    echo "cb-mpc not found under $CBMPC_HOME. Did you run scripts/install_cbmpc.sh?" >&2
+    exit 1
+  fi
 fi
 
 echo "Using CBMPC from $CBMPC_HOME"

--- a/scripts/source_cbmpc_env.sh
+++ b/scripts/source_cbmpc_env.sh
@@ -2,6 +2,15 @@
 set -euo pipefail
 
 CBMPC_HOME=${CBMPC_HOME:-/usr/local/opt/cbmpc}
+
+# Fall back to a nested cb-mpc directory if lib/include reside there
+if [ ! -d "$CBMPC_HOME/lib" ] || [ ! -d "$CBMPC_HOME/include" ]; then
+  alt="$CBMPC_HOME/cb-mpc"
+  if [ -d "$alt/lib" ] && [ -d "$alt/include" ]; then
+    CBMPC_HOME="$alt"
+  fi
+fi
+
 export CBMPC_HOME
 export LD_LIBRARY_PATH="$CBMPC_HOME/lib:${LD_LIBRARY_PATH:-}"
 export PKG_CONFIG_PATH="$CBMPC_HOME/lib/pkgconfig:${PKG_CONFIG_PATH:-}"


### PR DESCRIPTION
## Summary
- Handle cb-mpc installations where include/lib are inside a nested `cb-mpc` directory
- Make environment setup script detect cb-mpc installed inside the source tree
- Document fallback lookup in README

## Testing
- `./scripts/source_cbmpc_env.sh && echo "success" || echo "failed"` *(fails: no cb-mpc installation in container)*
- `./scripts/build_serverb.sh && echo "success" || echo "failed"` *(fails: cb-mpc not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8ac145a883219fcc0d829dd5ad84