### PR TITLE
fix build_serverb.sh to detect cb-mpc source tree layout

### DIFF
--- a/scripts/build_serverb.sh
+++ b/scripts/build_serverb.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CBMPC_HOME=${CBMPC_HOME:-/usr/local/opt/cbmpc}
+CBMPC_PREFIX=${CBMPC_HOME:-/usr/local/opt/cbmpc}
 
-# Ensure cb-mpc installation exists and fall back to a nested repository path
-# if the library was installed inside the cb-mpc source tree
-if [ ! -d "$CBMPC_HOME/include" ] || [ ! -d "$CBMPC_HOME/lib" ]; then
-  alt="$CBMPC_HOME/cb-mpc"
-  if [ -d "$alt/include" ] && [ -d "$alt/lib" ]; then
-    CBMPC_HOME="$alt"
-  else
-    echo "cb-mpc not found under $CBMPC_HOME. Did you run scripts/install_cbmpc.sh?" >&2
-    exit 1
-  fi
+# Determine include and library paths. Prefer the installed layout where
+# headers live under <prefix>/include and libraries under <prefix>/lib. If that
+# structure is missing, fall back to a built source tree in <prefix>/cb-mpc.
+if [ -d "$CBMPC_PREFIX/include" ] && [ -d "$CBMPC_PREFIX/lib" ]; then
+  CBMPC_INCLUDE="$CBMPC_PREFIX/include"
+  CBMPC_LIB="$CBMPC_PREFIX/lib"
+elif [ -d "$CBMPC_PREFIX/cb-mpc/ffi/c/include" ] \
+  && [ -d "$CBMPC_PREFIX/cb-mpc/target/release" ]; then
+  CBMPC_INCLUDE="$CBMPC_PREFIX/cb-mpc/ffi/c/include"
+  CBMPC_LIB="$CBMPC_PREFIX/cb-mpc/target/release"
+else
+  echo "cb-mpc not found under $CBMPC_PREFIX. Did you run scripts/install_cbmpc.sh?" >&2
+  exit 1
 fi
 
-echo "Using CBMPC from $CBMPC_HOME"
+echo "Using CBMPC from $CBMPC_PREFIX"
 
 # Create build directory
 mkdir -p build
@@ -26,8 +29,8 @@ pkg_config_cflags=$(pkg-config --cflags libcurl)
 pkg_config_libs=$(pkg-config --libs libcurl)
 
 g++ -std=c++17 ServerB/mpc_partyB.cpp ServerB/http_transport.cpp \
-    -I"$CBMPC_HOME/include" $pkg_config_cflags \
-    -L"$CBMPC_HOME/lib" -lcbmpc $pkg_config_libs \
+    -I"$CBMPC_INCLUDE" $pkg_config_cflags \
+    -L"$CBMPC_LIB" -lcbmpc $pkg_config_libs \
     -o build/mpc_partyB
 # Test: binary exists
 [ -x build/mpc_partyB ]


### PR DESCRIPTION
## Summary
- handle cb-mpc source tree built in-place by checking ffi headers and target lib paths
- pass include and lib directories to g++ accordingly

## Testing
- `./scripts/build_serverb.sh` *(fails: cb-mpc not found under /usr/local/opt/cbmpc)*

------
https://chatgpt.com/codex/tasks/task_e_68abb947a198832197d477c877aa6c26