### PR TITLE
Compile cb-mpc sources before installing

### DIFF
--- a/scripts/install_cbmpc.sh
+++ b/scripts/install_cbmpc.sh
@@ -21,9 +21,14 @@ git submodule update --init --recursive
 # Test: presence of Cargo.toml indicates repository ready
 [ -f Cargo.toml ]
 
-# Build FFI library
+# Build core cb-mpc library first to ensure sources are compiled
+cargo build --release -p cb-mpc
+# Test: core library built
+[ -f target/release/libcb_mpc.rlib ]
+
+# Build FFI library that ServerB links against
 cargo build --release -p cb-mpc-ffi
-# Test: library built
+# Test: FFI library built
 [ -f target/release/libcbmpc.a ]
 
 # Install library and header


### PR DESCRIPTION
## Summary
- compile core cb-mpc library before building FFI so installation leaves compiled artifacts

## Testing
- `CBMPC_HOME=/tmp/cbmpc bash scripts/install_cbmpc.sh` *(fails: unable to access `https://github.com/coinbase/cb-mpc.git/`: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abbb4f5fd483219af9f91eee0d3acf