### PR TITLE
Handle cb-mpc source tree layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ The `scripts/` directory contains helper scripts:
 1. `install_dependencies.sh` – installs system packages required for building and verifies they were installed.
 2. `install_cbmpc.sh` – clones the `cb-mpc` repository into `$CBMPC_HOME/cb-mpc`, builds it, and installs the FFI library under `/usr/local/opt/cbmpc` by default.
 3. `source_cbmpc_env.sh` – sets `CBMPC_HOME`, `LD_LIBRARY_PATH`, and `PKG_CONFIG_PATH` for the current shell.
-4. `build_serverb.sh` – compiles `ServerB/mpc_partyB.cpp` using the locally installed `cb-mpc` library.
+   It works whether `cb-mpc` has been installed under a prefix with `lib/`
+   and `include/` directories or if you're pointing `CBMPC_HOME` at a source
+   checkout containing the built artifacts in `target/release` and headers in
+   `ffi/c/include`.
+4. `build_serverb.sh` – compiles `ServerB/mpc_partyB.cpp` using the locally
+   installed `cb-mpc` library or directly against a built source tree.
 
 Each command in the scripts is followed by a simple test to ensure progress.
 
@@ -29,6 +34,7 @@ source ./scripts/source_cbmpc_env.sh
 ./scripts/build_serverb.sh
 ```
 
-Adjust `CBMPC_HOME` if the cb-mpc library is installed in a different location.
-The scripts will also check `$CBMPC_HOME/cb-mpc` in case the library and
-headers were installed inside the cb-mpc repository itself.
+Adjust `CBMPC_HOME` if the cb-mpc library is installed in a different location,
+or point it at a local `cb-mpc` checkout. The scripts automatically detect
+whether the library is installed under a prefix or only built inside the
+repository tree.

--- a/scripts/build_serverb.sh
+++ b/scripts/build_serverb.sh
@@ -4,26 +4,23 @@ set -euo pipefail
 CBMPC_PREFIX=${CBMPC_HOME:-/usr/local/opt/cbmpc}
 echo "CBMPC_PREFIX set to $CBMPC_PREFIX" >&2
 
-# Determine include and library paths. Prefer the installed layout where
-# headers live under <prefix>/include and libraries under <prefix>/lib. Some
-# systems may place libraries in <prefix>/lib64, so account for that. If neither
-# layout is present, fall back to a built source tree in <prefix>/cb-mpc.
-if [ -d "$CBMPC_PREFIX/include" ]; then
-  if [ -d "$CBMPC_PREFIX/lib" ]; then
-    CBMPC_INCLUDE="$CBMPC_PREFIX/include"
-    CBMPC_LIB="$CBMPC_PREFIX/lib"
-  elif [ -d "$CBMPC_PREFIX/lib64" ]; then
-    CBMPC_INCLUDE="$CBMPC_PREFIX/include"
-    CBMPC_LIB="$CBMPC_PREFIX/lib64"
-  fi
-fi
-
-if [ -z "${CBMPC_INCLUDE:-}" ] || [ -z "${CBMPC_LIB:-}" ]; then
-  if [ -d "$CBMPC_PREFIX/cb-mpc/ffi/c/include" ] \
-     && [ -d "$CBMPC_PREFIX/cb-mpc/target/release" ]; then
-    CBMPC_INCLUDE="$CBMPC_PREFIX/cb-mpc/ffi/c/include"
-    CBMPC_LIB="$CBMPC_PREFIX/cb-mpc/target/release"
-  fi
+# Determine include and library paths. Support three layouts:
+# 1) an installed prefix with include/ and lib/ (or lib64/) directories,
+# 2) a source checkout provided directly via CBMPC_HOME containing
+#    ffi/c/include and target/release, or
+# 3) a checkout nested under <prefix>/cb-mpc with the same structure.
+if [ -d "$CBMPC_PREFIX/include" ] && [ -d "$CBMPC_PREFIX/lib" ]; then
+  CBMPC_INCLUDE="$CBMPC_PREFIX/include"
+  CBMPC_LIB="$CBMPC_PREFIX/lib"
+elif [ -d "$CBMPC_PREFIX/include" ] && [ -d "$CBMPC_PREFIX/lib64" ]; then
+  CBMPC_INCLUDE="$CBMPC_PREFIX/include"
+  CBMPC_LIB="$CBMPC_PREFIX/lib64"
+elif [ -d "$CBMPC_PREFIX/ffi/c/include" ] && [ -d "$CBMPC_PREFIX/target/release" ]; then
+  CBMPC_INCLUDE="$CBMPC_PREFIX/ffi/c/include"
+  CBMPC_LIB="$CBMPC_PREFIX/target/release"
+elif [ -d "$CBMPC_PREFIX/cb-mpc/ffi/c/include" ] && [ -d "$CBMPC_PREFIX/cb-mpc/target/release" ]; then
+  CBMPC_INCLUDE="$CBMPC_PREFIX/cb-mpc/ffi/c/include"
+  CBMPC_LIB="$CBMPC_PREFIX/cb-mpc/target/release"
 fi
 
 if [ -z "${CBMPC_INCLUDE:-}" ] || [ -z "${CBMPC_LIB:-}" ]; then

--- a/scripts/source_cbmpc_env.sh
+++ b/scripts/source_cbmpc_env.sh
@@ -3,20 +3,31 @@ set -euo pipefail
 
 CBMPC_HOME=${CBMPC_HOME:-/usr/local/opt/cbmpc}
 
-# Fall back to a nested cb-mpc directory if lib/include reside there
-if [ ! -d "$CBMPC_HOME/lib" ] || [ ! -d "$CBMPC_HOME/include" ]; then
-  alt="$CBMPC_HOME/cb-mpc"
-  if [ -d "$alt/lib" ] && [ -d "$alt/include" ]; then
-    CBMPC_HOME="$alt"
-  fi
+# Determine where the cb-mpc library artifacts live. Support both an
+# installed layout with lib/include directories and a source checkout
+# where the build artifacts reside in target/release and headers under
+# ffi/c/include.
+if [ -d "$CBMPC_HOME/lib" ]; then
+  libdir="$CBMPC_HOME/lib"
+elif [ -d "$CBMPC_HOME/lib64" ]; then
+  libdir="$CBMPC_HOME/lib64"
+elif [ -d "$CBMPC_HOME/target/release" ]; then
+  libdir="$CBMPC_HOME/target/release"
+elif [ -d "$CBMPC_HOME/cb-mpc/target/release" ]; then
+  CBMPC_HOME="$CBMPC_HOME/cb-mpc"
+  libdir="$CBMPC_HOME/target/release"
+else
+  echo "cb-mpc libraries not found under $CBMPC_HOME" >&2
+  exit 1
 fi
 
 export CBMPC_HOME
-export LD_LIBRARY_PATH="$CBMPC_HOME/lib:${LD_LIBRARY_PATH:-}"
-export PKG_CONFIG_PATH="$CBMPC_HOME/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+export LD_LIBRARY_PATH="$libdir:${LD_LIBRARY_PATH:-}"
+export PKG_CONFIG_PATH="$libdir/pkgconfig:${PKG_CONFIG_PATH:-}"
 
 # Tests: print variables to confirm
 [ -d "$CBMPC_HOME" ]
+[ -d "$libdir" ]
 [ -n "$LD_LIBRARY_PATH" ]
 [ -n "$PKG_CONFIG_PATH" ]
 


### PR DESCRIPTION
## Summary
- extend `source_cbmpc_env.sh` and `build_serverb.sh` to detect cb-mpc libraries and headers in either an installed prefix or a source checkout
- clarify README usage for source tree builds

## Testing
- `./scripts/install_dependencies.sh` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `./scripts/install_cbmpc.sh` *(fails: fatal: unable to access 'https://github.com/coinbase/cb-mpc.git/': CONNECT tunnel failed, response 403)*
- `bash ./scripts/source_cbmpc_env.sh` *(fails: cb-mpc libraries not found under /usr/local/opt/cbmpc)*
- `./scripts/build_serverb.sh` *(fails: cb-mpc not found under /usr/local/opt/cbmpc)*

------
https://chatgpt.com/codex/tasks/task_e_68abc1760a1c8321b50f33d26c1b27da