### PR TITLE
CMake root build and demo fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.20)
+project(cbmpc_demo LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Where cb-mpc was installed by 'sudo make install'.
+# Default matches our bootstrap: /usr/local/opt/cbmpc
+if(NOT DEFINED CBMPC_PREFIX)
+  if(DEFINED ENV{CBMPC_PREFIX})
+    set(CBMPC_PREFIX "$ENV{CBMPC_PREFIX}")
+  else()
+    set(CBMPC_PREFIX "/usr/local/opt/cbmpc")
+  endif()
+endif()
+
+# OpenSSL prefix (default from our bootstrap)
+if(NOT DEFINED OPENSSL_ROOT_DIR)
+  if(DEFINED ENV{OPENSSL_ROOT_DIR})
+    set(OPENSSL_ROOT_DIR "$ENV{OPENSSL_ROOT_DIR}")
+  else()
+    set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl@3.2.0")
+  endif()
+endif()
+
+find_package(Threads REQUIRED)
+find_package(OpenSSL REQUIRED)
+
+# Find cb-mpc static library + headers
+find_library(CBMPC_LIBRARY NAMES cbmpc HINTS "${CBMPC_PREFIX}/lib" REQUIRED)
+set(CBMPC_INCLUDE_DIR "${CBMPC_PREFIX}/include")
+
+# Optional: GMP
+find_library(GMP_LIBRARY NAMES gmp)
+
+set(CBMPC_DEMO_COMMON_LIBS ${CBMPC_LIBRARY} OpenSSL::SSL OpenSSL::Crypto Threads::Threads dl m)
+if(GMP_LIBRARY)
+  list(APPEND CBMPC_DEMO_COMMON_LIBS ${GMP_LIBRARY})
+endif()
+
+add_subdirectory(ServerA)
+add_subdirectory(ServerB)

--- a/ServerA/CMakeLists.txt
+++ b/ServerA/CMakeLists.txt
@@ -1,16 +1,4 @@
-# CMakeLists.txt snippet
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(CURL REQUIRED libcurl)
-
-include_directories(/usr/local/opt/cbmpc/include)   # adjust if installed elsewhere
-link_directories(/usr/local/opt/cbmpc/lib)
-
-add_library(http_transport http_transport.cpp)
-target_include_directories(http_transport PUBLIC ${CURL_INCLUDE_DIRS})
-target_link_libraries(http_transport ${CURL_LIBRARIES})
-
-add_executable(mpc_partyA ServerA/mpc_partyA.cpp)
-target_link_libraries(mpc_partyA http_transport cbmpc ${CURL_LIBRARIES})
-
-add_executable(mpc_partyB ServerB/mpc_partyB.cpp)
-target_link_libraries(mpc_partyB http_transport cbmpc ${CURL_LIBRARIES})
+# Party A target
+add_executable(mpc_partyA mpc_partyA.cpp)
+target_include_directories(mpc_partyA PRIVATE "${CBMPC_INCLUDE_DIR}")
+target_link_libraries(mpc_partyA PRIVATE ${CBMPC_DEMO_COMMON_LIBS})

--- a/ServerB/CMakeLists.txt
+++ b/ServerB/CMakeLists.txt
@@ -1,16 +1,4 @@
-# CMakeLists.txt snippet
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(CURL REQUIRED libcurl)
-
-include_directories(/usr/local/opt/cbmpc/include)   # adjust if installed elsewhere
-link_directories(/usr/local/opt/cbmpc/lib)
-
-add_library(http_transport http_transport.cpp)
-target_include_directories(http_transport PUBLIC ${CURL_INCLUDE_DIRS})
-target_link_libraries(http_transport ${CURL_LIBRARIES})
-
-add_executable(mpc_partyA ServerA/mpc_partyA.cpp)
-target_link_libraries(mpc_partyA http_transport cbmpc ${CURL_LIBRARIES})
-
-add_executable(mpc_partyB ServerB/mpc_partyB.cpp)
-target_link_libraries(mpc_partyB http_transport cbmpc ${CURL_LIBRARIES})
+# Party B target
+add_executable(mpc_partyB mpc_partyB.cpp)
+target_include_directories(mpc_partyB PRIVATE "${CBMPC_INCLUDE_DIR}")
+target_link_libraries(mpc_partyB PRIVATE ${CBMPC_DEMO_COMMON_LIBS})

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,21 @@
+# Build & Run (cb-mpc-demo)
+
+This demo expects **cb-mpc** to be installed (e.g., via `sudo make install` from the cb-mpc repo)
+and **OpenSSL 3.2.0 (static)** at `/usr/local/opt/openssl@3.2.0`.
+
+## Build
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j"$(nproc)"
+```
+
+If your prefixes differ:
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH=/path/to/cbmpc \
+  -DOPENSSL_ROOT_DIR=/path/to/openssl
+```
+
+## Binaries
+- `build/ServerA/mpc_partyA`
+- `build/ServerB/mpc_partyB`


### PR DESCRIPTION
## Summary
- add top-level CMake build with cbmpc and OpenSSL discovery
- simplify ServerA/ServerB targets for linking against cbmpc static libs
- add BUILD instructions for building demo binaries

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find CBMPC_LIBRARY)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ab78b70c832180cd69ecc4594c6b