### PR TITLE
Add CMake build configuration for demo servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/build/
+/CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.20)
-project(cbmpc_demo LANGUAGES CXX)
+project(cbmpc_demo LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Where cb-mpc was installed by 'sudo make install'.
-# Default matches our bootstrap: /usr/local/opt/cbmpc
+# Where cb-mpc was installed by 'sudo make install'
 if(NOT DEFINED CBMPC_PREFIX)
   if(DEFINED ENV{CBMPC_PREFIX})
     set(CBMPC_PREFIX "$ENV{CBMPC_PREFIX}")
@@ -15,7 +14,7 @@ if(NOT DEFINED CBMPC_PREFIX)
   endif()
 endif()
 
-# OpenSSL prefix (default from our bootstrap)
+# OpenSSL (static build default path from our setup)
 if(NOT DEFINED OPENSSL_ROOT_DIR)
   if(DEFINED ENV{OPENSSL_ROOT_DIR})
     set(OPENSSL_ROOT_DIR "$ENV{OPENSSL_ROOT_DIR}")
@@ -24,19 +23,55 @@ if(NOT DEFINED OPENSSL_ROOT_DIR)
   endif()
 endif()
 
+# Help CMake look under these prefixes
+if(CMAKE_PREFIX_PATH)
+  list(APPEND CMAKE_PREFIX_PATH "${CBMPC_PREFIX}" "${OPENSSL_ROOT_DIR}")
+else()
+  set(CMAKE_PREFIX_PATH "${CBMPC_PREFIX};${OPENSSL_ROOT_DIR}")
+endif()
+
 find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
 
-# Find cb-mpc static library + headers
+# cb-mpc static lib
 find_library(CBMPC_LIBRARY NAMES cbmpc HINTS "${CBMPC_PREFIX}/lib" REQUIRED)
-set(CBMPC_INCLUDE_DIR "${CBMPC_PREFIX}/include")
 
-# Optional: GMP
-find_library(GMP_LIBRARY NAMES gmp)
+# Installed headers
+find_path(CBMPC_INCLUDE_DIR
+  NAMES cbmpc/protocol/mpc_job.h cbmpc/crypto/base.h
+  HINTS "${CBMPC_PREFIX}/include" "/usr/local/include" "/usr/include"
+  REQUIRED)
 
-set(CBMPC_DEMO_COMMON_LIBS ${CBMPC_LIBRARY} OpenSSL::SSL OpenSSL::Crypto Threads::Threads dl m)
-if(GMP_LIBRARY)
-  list(APPEND CBMPC_DEMO_COMMON_LIBS ${GMP_LIBRARY})
+# Optional: cb-mpc source tree for internal headers like cbmpc/crypto/ec/ec.h
+if(NOT CBMPC_SOURCE_DIR AND DEFINED ENV{CBMPC_SOURCE_DIR})
+  set(CBMPC_SOURCE_DIR "$ENV{CBMPC_SOURCE_DIR}")
+endif()
+if(NOT CBMPC_SOURCE_DIR)
+  foreach(p "${CBMPC_PREFIX}/src" "${CMAKE_SOURCE_DIR}/../cb-mpc/src" "$ENV{HOME}/cb-mpc/src")
+    if(EXISTS "${p}/cbmpc/crypto")
+      set(CBMPC_SOURCE_DIR "${p}")
+      break()
+    endif()
+  endforeach()
+endif()
+
+message(STATUS "CBMPC_PREFIX=${CBMPC_PREFIX}")
+message(STATUS "OPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}")
+message(STATUS "CBMPC_INCLUDE_DIR=${CBMPC_INCLUDE_DIR}")
+message(STATUS "CBMPC_SOURCE_DIR=${CBMPC_SOURCE_DIR}")
+
+set(CBMPC_DEMO_COMMON_LIBS
+  ${CBMPC_LIBRARY}
+  OpenSSL::SSL
+  OpenSSL::Crypto
+  Threads::Threads
+  dl
+  m
+)
+
+# Reduce noisy warnings from upstream headers when using Clang
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-parentheses)
 endif()
 
 add_subdirectory(ServerA)

--- a/ServerA/CMakeLists.txt
+++ b/ServerA/CMakeLists.txt
@@ -1,4 +1,8 @@
-# Party A target
 add_executable(mpc_partyA mpc_partyA.cpp)
+
 target_include_directories(mpc_partyA PRIVATE "${CBMPC_INCLUDE_DIR}")
+if(CBMPC_SOURCE_DIR)
+  target_include_directories(mpc_partyA PRIVATE "${CBMPC_SOURCE_DIR}")
+endif()
+
 target_link_libraries(mpc_partyA PRIVATE ${CBMPC_DEMO_COMMON_LIBS})

--- a/ServerB/CMakeLists.txt
+++ b/ServerB/CMakeLists.txt
@@ -1,4 +1,8 @@
-# Party B target
 add_executable(mpc_partyB mpc_partyB.cpp)
+
 target_include_directories(mpc_partyB PRIVATE "${CBMPC_INCLUDE_DIR}")
+if(CBMPC_SOURCE_DIR)
+  target_include_directories(mpc_partyB PRIVATE "${CBMPC_SOURCE_DIR}")
+endif()
+
 target_link_libraries(mpc_partyB PRIVATE ${CBMPC_DEMO_COMMON_LIBS})

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,21 +1,28 @@
 # Build & Run (cb-mpc-demo)
 
-This demo expects **cb-mpc** to be installed (e.g., via `sudo make install` from the cb-mpc repo)
+This demo expects **cb-mpc** to be installed (e.g., via `sudo make install` in the cb-mpc repo)
 and **OpenSSL 3.2.0 (static)** at `/usr/local/opt/openssl@3.2.0`.
 
 ## Build
 ```bash
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j"$(nproc)"
-```
+
 
 If your prefixes differ:
-```bash
+
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_PREFIX_PATH=/path/to/cbmpc \
   -DOPENSSL_ROOT_DIR=/path/to/openssl
-```
 
-## Binaries
-- `build/ServerA/mpc_partyA`
-- `build/ServerB/mpc_partyB`
+
+Optionally, if your demo includes internal headers from the cb-mpc source tree, set:
+
+export CBMPC_SOURCE_DIR=$HOME/cb-mpc/src
+
+Binaries
+
+build/ServerA/mpc_partyA
+
+build/ServerB/mpc_partyB
+```


### PR DESCRIPTION
## Summary
- Add root CMake config that locates cb-mpc and OpenSSL and builds ServerA and ServerB
- Simplify ServerA/B CMakeLists with shared include paths and libraries
- Document build steps and ignore build artifacts

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find CBMPC_LIBRARY)*
- `cmake --build build -j"$(nproc)"` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68b1b1e5dacc832199651233de5ed71e