### PR TITLE
Fix cbmpc include path and add CMake project headers

### DIFF
--- a/ServerA/CMakeLists.txt
+++ b/ServerA/CMakeLists.txt
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.20)
+project(mpc_partyA LANGUAGES CXX)
+
 add_executable(mpc_partyA mpc_partyA.cpp)
 
 target_include_directories(mpc_partyA PRIVATE "${CBMPC_INCLUDE_DIR}")

--- a/ServerA/mpc_partyA.cpp
+++ b/ServerA/mpc_partyA.cpp
@@ -6,7 +6,7 @@
 
 // cb-mpc
 #include <cbmpc/protocol/ecdsa_2p.h>       // coinbase::mpc::ecdsa2pc::{dkg, sign}
-#include <cbmpc/crypto/ec/ec.h>            // curve definitions, key utils
+#include <cbmpc/crypto/ec.h>               // curve definitions, key utils
 #include <cbmpc/core/mem.h>
 #include <cbmpc/core/error.h>
 #include <cbmpc/protocol/data_transport.h>

--- a/ServerB/CMakeLists.txt
+++ b/ServerB/CMakeLists.txt
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.20)
+project(mpc_partyB LANGUAGES CXX)
+
 add_executable(mpc_partyB mpc_partyB.cpp)
 
 target_include_directories(mpc_partyB PRIVATE "${CBMPC_INCLUDE_DIR}")

--- a/ServerB/mpc_partyB.cpp
+++ b/ServerB/mpc_partyB.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include <cbmpc/protocol/ecdsa_2p.h>
-#include <cbmpc/crypto/ec/ec.h>
+#include <cbmpc/crypto/ec.h>
 #include <cbmpc/core/mem.h>
 #include <cbmpc/core/error.h>
 #include <cbmpc/protocol/data_transport.h>


### PR DESCRIPTION
## Summary
- fix elliptic curve header include path for cb-mpc
- define project and cmake_minimum_required in ServerA/ServerB CMakeLists

## Testing
- `cmake -S . -B build` *(fails: Could not find CBMPC_LIBRARY using the following names: cbmpc)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b560a22c83219b2660e648392ce7