### PR TITLE
fix: update ec header path

### DIFF
--- a/ServerA/mpc_partyA.cpp
+++ b/ServerA/mpc_partyA.cpp
@@ -6,7 +6,8 @@
 
 // cb-mpc
 #include <cbmpc/protocol/ecdsa_2p.h>       // coinbase::mpc::ecdsa2pc::{dkg, sign}
-#include <cbmpc/crypto/ec.h>               // curve definitions, key utils
+// Newer versions of cb-mpc moved EC helpers under crypto/ec/.
+#include <cbmpc/crypto/ec/ec.h>            // curve definitions, key utils
 #include <cbmpc/core/mem.h>
 #include <cbmpc/core/error.h>
 #include <cbmpc/protocol/data_transport.h>

--- a/ServerB/mpc_partyB.cpp
+++ b/ServerB/mpc_partyB.cpp
@@ -5,7 +5,8 @@
 #include <vector>
 
 #include <cbmpc/protocol/ecdsa_2p.h>
-#include <cbmpc/crypto/ec.h>
+// EC utilities moved under crypto/ec/ in recent cb-mpc versions
+#include <cbmpc/crypto/ec/ec.h>
 #include <cbmpc/core/mem.h>
 #include <cbmpc/core/error.h>
 #include <cbmpc/protocol/data_transport.h>


### PR DESCRIPTION
## Summary
- update server demo sources to include EC helpers from new cb-mpc header location

## Testing
- `DEMO_DIR=$(pwd) bash ServerA/scripts/40-build-demo.sh` *(fails: Could not find CBMPC_LIBRARY using the following names: cbmpc)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b980d6dc8321a7f2a80decd0c8ce